### PR TITLE
fix: fix display when ms lte0

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -194,11 +194,11 @@ fn update_stats(ip_data: Arc<Mutex<Vec<IpData>>>, i: usize, addr: IpAddr, rtt: f
 // update timeout statistics
 fn update_timeout_stats(ip_data: Arc<Mutex<Vec<IpData>>>, i: usize, addr: IpAddr) {
     let mut data = ip_data.lock().unwrap();
-    data[i].rtts.push_back(0.0);
+    data[i].rtts.push_back(-1.0);
     data[i].ip = addr.to_string();
+    data[i].timeout += 1;
     if data[i].rtts.len() > 10 {
         data[i].rtts.pop_front();
-        data[i].timeout += 1;
         data[i].pop_count += 1;
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -195,6 +195,7 @@ fn update_stats(ip_data: Arc<Mutex<Vec<IpData>>>, i: usize, addr: IpAddr, rtt: f
 fn update_timeout_stats(ip_data: Arc<Mutex<Vec<IpData>>>, i: usize, addr: IpAddr) {
     let mut data = ip_data.lock().unwrap();
     data[i].rtts.push_back(-1.0);
+    data[i].last_attr = -1.0;
     data[i].ip = addr.to_string();
     data[i].timeout += 1;
     if data[i].rtts.len() > 10 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -141,6 +141,8 @@ pub fn draw_interface<B: Backend>(
                         Span::styled(
                             if data.last_attr == 0.0 {
                                 "< 0.01ms".to_string()
+                            } else if data.last_attr == -1.0 {
+                                "0.0ms".to_string()
                             } else {
                                 format!("{:?}ms", data.last_attr)
                             },

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -78,12 +78,13 @@ pub fn draw_interface<B: Backend>(
                     0.0
                 };
 
-                let loss_pkg_color = if loss_pkg > 0.0 {
+                let loss_pkg_color = if loss_pkg > 50.0 {
                     Color::Red
+                } else if loss_pkg > 0.0 {
+                    Color::Yellow
                 } else {
                     Color::Green
                 };
-
 
                 // render the content of each target
                 let render_content = |f: &mut Frame, area: Rect| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -78,6 +78,12 @@ pub fn draw_interface<B: Backend>(
                     0.0
                 };
 
+                let loss_pkg_color = if loss_pkg > 0.0 {
+                    Color::Red
+                } else {
+                    Color::Green
+                };
+
 
                 // render the content of each target
                 let render_content = |f: &mut Frame, area: Rect| {
@@ -98,8 +104,13 @@ pub fn draw_interface<B: Backend>(
 
                     // render the content of each target
                     let avg_rtt = if !data.rtts.is_empty() {
-                        let sum: f64 = data.rtts.iter().sum();
-                        sum / data.rtts.len() as f64
+                        let valid_rtt: Vec<f64> = data.rtts.iter().cloned().filter(|&rtt| rtt >= 0.0).collect();
+                        if !valid_rtt.is_empty() {
+                            let sum: f64 = valid_rtt.iter().sum();
+                            sum / valid_rtt.len() as f64
+                        } else {
+                            0.0
+                        }
                     } else {
                         0.0
                     };
@@ -126,7 +137,14 @@ pub fn draw_interface<B: Backend>(
 
                     let base_metric_text = Line::from(vec![
                         Span::styled("last: ", Style::default()),
-                        Span::styled(format!("{:?}ms", data.last_attr), Style::default().fg(Color::Green)),
+                        Span::styled(
+                            if data.last_attr == 0.0 {
+                                "< 0.01ms".to_string()
+                            } else {
+                                format!("{:?}ms", data.last_attr)
+                            },
+                            Style::default().fg(Color::Green)
+                        ),
                         Span::raw("  "),
                         Span::styled("avg rtt : ", Style::default()),
                         Span::styled(format!("{:.2} ms", avg_rtt), Style::default().fg(Color::Green)),
@@ -141,7 +159,7 @@ pub fn draw_interface<B: Backend>(
                         Span::styled(format!("{:.2} ms", data.min_rtt), Style::default().fg(Color::Green)),
                         Span::raw("  "),
                         Span::styled("loss: ", Style::default()),
-                        Span::styled(format!("{:.2}%", loss_pkg), Style::default().fg(Color::Green)),
+                        Span::styled(format!("{:.2}%", loss_pkg), Style::default().fg(loss_pkg_color)),
                     ]);
 
 
@@ -203,12 +221,12 @@ pub fn draw_interface<B: Backend>(
                         .rev()
                         .take(5)
                         .map(|&rtt| {
-                            let display_text = if rtt == 0.0 {
+                            let display_text = if rtt == -1.0 {
                                 "timeout".to_string()
                             } else {
                                 format!("{}ms", rtt)
                             };
-                            let display_color = if rtt == 0.0 {
+                            let display_color = if rtt == -1.0  {
                                 Color::Red
                             } else {
                                 Color::Green


### PR DESCRIPTION
## 改动

一:
 
不在使用 0ms 作为异常标志位，修改为 -1。当某些特殊情况下 ping 输出为 0 时, 展示 延迟 < 0.01 ms

![image](https://github.com/user-attachments/assets/e62e4a2e-f6a2-4592-8c7b-f7405b5803bb)


二:

优化丢包时的异常展示, 当出现丢包情况时，新增丢包率指标分为 3 个阶段
- 高于百分之 50 丢包率为 红色，并亮红灯
- 低于百分之 50 丢包率但是大于 0 ，字体展示为黄色
- 丢包率为 0 时展示绿色。

![image](https://github.com/user-attachments/assets/e62e4a2e-f6a2-4592-8c7b-f7405b5803bb)

