### PR TITLE
feat: add Nix flake support for declarative installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,42 @@ brew install nbping
 nbping --help
 ```
 
+#### Nix/NixOS
+
+For users with Nix installed, you can use NBping without installing it:
+
+```bash
+# Run directly
+nix run github:hanshuaikang/Nping
+
+# Try it in a temporary shell
+nix shell github:hanshuaikang/Nping
+nbping --version
+
+# Add to your NixOS configuration or home-manager
+{
+  environment.systemPackages = [
+    inputs.nbping.packages.${system}.default
+  ];
+}
+```
+
+To build from source with Nix:
+
+```bash
+nix build
+nix run . -- --version
+```
+
+For development:
+
+```bash
+nix develop
+cargo build
+```
+
+For maintainers updating the flake, see [docs/maintaining-nix-flake.md](docs/maintaining-nix-flake.md).
+
 ## Feature:
 - TCP Ping support
 - IP range Ping support

--- a/docs/maintaining-nix-flake.md
+++ b/docs/maintaining-nix-flake.md
@@ -1,0 +1,65 @@
+# Maintaining the Nix Flake after new NBping release
+
+When releasing a new version of NBping, follow these steps to update the Nix flake:
+
+## 1. Update Version in flake.nix
+
+Update the `version` field in `flake.nix` to match the new release version:
+
+```nix
+version = "0.6.2";  # Update this to the new version
+```
+## 2. Update flake.lock
+
+Update the lock file to get the latest nixpkgs:
+
+```bash
+nix flake update
+```
+
+## 3. Update Cargo Hash (if dependencies changed)
+
+If you've added, removed, or updated dependencies in `Cargo.toml`, you need to recalculate the `cargoHash`:
+
+```bash
+# Stage your changes
+git add flake.nix Cargo.toml Cargo.lock
+
+# Clear the hash temporarily
+sed -i 's/cargoHash = ".*"/cargoHash = ""/' flake.nix
+
+# Run build to get the correct hash
+nix build --no-link 2>&1 | grep "got:"
+
+# Copy the hash from the output and update flake.nix
+# Example output: got:    sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=
+```
+
+Update the `cargoHash` in `flake.nix` with the value from the output.
+
+## 4. Test the Build
+
+Verify everything works correctly:
+
+```bash
+# Test build
+nix build --no-link
+
+# Test version output
+nix run . -- --version
+
+# Verify flake structure
+nix flake check
+
+# Test development shell
+nix develop -c cargo --version
+```
+
+## 5. Commit Changes
+
+Commit all changes together:
+
+```bash
+git add flake.nix flake.lock
+git commit -m "chore: update Nix flake for v0.6.2 release"
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "NBping - A Ping tool developed in Rust with concurrent support, visual charts, and real-time data updates";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "nbping";
+            version = "0.6.1";
+
+            src = ./.;
+
+            cargoHash = "sha256-6+drbq9dQ5/Atzoz9VPS4BoYEPeM5OqPXUuM1AXP72g=";
+
+            meta = with pkgs.lib; {
+              description = "NBping is a Ping tool developed in Rust. It supports concurrent Ping for multiple addresses, visual chart display, real-time data updates, and other features";
+              homepage = "https://github.com/hanshuaikang/Nping";
+              license = licenses.mit;
+              mainProgram = "nbping";
+            };
+          };
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/nbping";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              cargo
+              rustc
+              rust-analyzer
+              rustfmt
+              clippy
+            ];
+
+            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
- Added Nix/NixOS installation section with three usage methods
- Included examples for direct run, temporary shell, and NixOS configuration
- Created docs/maintaining-nix-flake.md