### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,4 @@ Thanks to these self-media for reposting and paying attention to 🏎NBping!
 | [X:@geekbb](https://x.com/geekbb/status/1875754541905539510) | [公众号:一飞开源](https://mp.weixin.qq.com/s/BZjr54h8dIQgzr8UW3fwOQ) | [公众号: 开源日记](https://mp.weixin.qq.com/s/uGtkD4x_XOFyKNbIy5pHYA)
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=hanshuaikang/Nping&type=Date)](https://star-history.com/#hanshuaikang/Nping&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hanshuaikang/Nping&type=Date)](https://star-history.dera.page/#hanshuaikang/Nping&Date)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -159,4 +159,4 @@ port: 9090             # 仅 exporter 模式
 | [X:@geekbb](https://x.com/geekbb/status/1875754541905539510) | [公众号:一飞开源](https://mp.weixin.qq.com/s/BZjr54h8dIQgzr8UW3fwOQ) ｜ [公众号: 开源日记](https://mp.weixin.qq.com/s/uGtkD4x_XOFyKNbIy5pHYA)
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=hanshuaikang/Nping&type=Date)](https://star-history.com/#hanshuaikang/Nping&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hanshuaikang/Nping&type=Date)](https://star-history.dera.page/#hanshuaikang/Nping&Date)


### PR DESCRIPTION
The Star History chart in README.md and README_ZH.md is currently broken and does not render. This change moves both the image and its link to a working alternative host so the chart shows correctly again.